### PR TITLE
Fix README markup of code samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Features:
       if (index != Spinner.INVALID_POSITION) {
           action(actions[index]);
       }
-  });
+   });
    ```
 
 
@@ -35,7 +35,7 @@ Features:
 
  - [switch for "string"](app/src/main/java/com/annimon/java8streamexample/MainActivity.java#L85)
  
-   ```java
+  ```java
   switch (action) {
       case "filter 1":
           // Filter one word


### PR DESCRIPTION
Looks like markup is broken now because of some wrong placed spaces